### PR TITLE
Adjusting user page widgets to smaller screens, fix #95 

### DIFF
--- a/lib/features/user/presentation/pages/user_pages.dart
+++ b/lib/features/user/presentation/pages/user_pages.dart
@@ -208,7 +208,7 @@ class UserStatusPageState extends State<UserStatusPage> {
                 Row(
                   children: [
                     ConstrainedBox(
-                      constraints: BoxConstraints.tightFor(width: SizeConfig.width(40)),
+                      constraints: BoxConstraints.tightFor(width: SizeConfig.width(42)),
                       child: child,
                     ),
                     Spacer(flex: 1),
@@ -329,10 +329,13 @@ class UserStatusPageState extends State<UserStatusPage> {
       mainAxisSize: MainAxisSize.max,
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        _buildOperationName(operation, context),
-        Spacer(),
-        _buildActivityStatus(context),
-        Spacer(),
+        Expanded(
+          child: _buildOperationName(operation, context),
+    ),
+        Padding(
+          padding: EdgeInsets.all(5.0),
+          child: _buildActivityStatus(context),
+        ),
         Chip(
           elevation: 2,
           avatar: Icon(

--- a/lib/features/user/presentation/pages/user_pages.dart
+++ b/lib/features/user/presentation/pages/user_pages.dart
@@ -331,7 +331,7 @@ class UserStatusPageState extends State<UserStatusPage> {
       children: [
         Expanded(
           child: _buildOperationName(operation, context),
-    ),
+        ),
         Padding(
           padding: EdgeInsets.all(5.0),
           child: _buildActivityStatus(context),


### PR DESCRIPTION
Long mission names will no longer cause render overflow, but split on multiple lines.

Gave more width to position accuracy, so header will not split on multiple lines on a standard mobile screen.