### PR TITLE
Update coordinate field when searching, remove Overflow issue. Close #71

### DIFF
--- a/lib/features/operation/presentation/editors/operation_editor.dart
+++ b/lib/features/operation/presentation/editors/operation_editor.dart
@@ -284,7 +284,7 @@ class _OperationEditorState extends State<OperationEditor> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               _buildCopyFromMeetupButton(),
-              FlatButton.icon(
+              TextButton.icon(
                 icon: Icon(Icons.my_location),
                 label: Text("Min posisjon"),
                 onPressed: () => _setIppToMe(),
@@ -298,7 +298,7 @@ class _OperationEditorState extends State<OperationEditor> {
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
               _buildCopyFromIppButton(),
-              FlatButton.icon(
+              TextButton.icon(
                 icon: Icon(Icons.my_location),
                 label: Text("Min posisjon"),
                 onPressed: () => _setMeetupToMe(),
@@ -637,7 +637,7 @@ class _OperationEditorState extends State<OperationEditor> {
         style: TextStyle(fontSize: 16.0),
       );
 
-  Widget _buildCopyFromIppButton() => FlatButton.icon(
+  Widget _buildCopyFromIppButton() => TextButton.icon(
         icon: Icon(Icons.content_copy),
         label: Text("IPP"),
         onPressed: _ipp is Location
@@ -654,7 +654,7 @@ class _OperationEditorState extends State<OperationEditor> {
             : null,
       );
 
-  Widget _buildCopyFromMeetupButton() => FlatButton.icon(
+  Widget _buildCopyFromMeetupButton() => TextButton.icon(
         icon: Icon(Icons.content_copy),
         label: Text("Oppmøte"),
         onPressed: _meetup is Location

--- a/lib/features/tracking/presentation/editors/position_editor.dart
+++ b/lib/features/tracking/presentation/editors/position_editor.dart
@@ -227,9 +227,7 @@ class _PositionEditorState extends State<PositionEditor> with TickerProviderStat
   }
 
   void _onPositionChanged(MapPosition position, bool hasGesture) {
-    if (hasGesture) {
-      _setFromLatLng(position.center);
-      _changes.add(position.center);
-    }
+    _setFromLatLng(position.center);
+    _changes.add(position.center);
   }
 }


### PR DESCRIPTION
Coordinates in search box did not update if there was no gesture, for example when selecting from a list of search results, or using the myLocation button.

Also changed some widgtes from FlatButton to TextButton, and solving overflow issue. See: https://docs.google.com/document/d/1yohSuYrvyya5V1hB6j9pJskavCdVq9sVeTqSoEPsWH0/edit


