### PR TITLE
Move location debug setting to AppConfig, closing #114

### DIFF
--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -684,6 +684,7 @@ class AppController {
       ).configure(
         token: bloc<UserBloc>().repo.token,
         duuid: bloc<DeviceBloc>().findThisApp()?.uuid,
+        locationDebug: bloc<AppConfigBloc>().config?.locationDebug,
       );
     }
   }

--- a/lib/core/app_controller.dart
+++ b/lib/core/app_controller.dart
@@ -684,7 +684,7 @@ class AppController {
       ).configure(
         token: bloc<UserBloc>().repo.token,
         duuid: bloc<DeviceBloc>().findThisApp()?.uuid,
-        locationDebug: bloc<AppConfigBloc>().config?.locationDebug,
+        debug: bloc<AppConfigBloc>().config?.locationDebug,
       );
     }
   }

--- a/lib/core/defaults.dart
+++ b/lib/core/defaults.dart
@@ -38,6 +38,8 @@ class Defaults {
 
   static final LatLng origo = LatLng(59.5, 10.09);
 
+  static const bool locationDebug = false;
+
   static final bool debugPrintHttp = true;
   static final bool debugPrintLocation = false;
   static final bool debugPrintCommands = false;

--- a/lib/features/activity/presentation/blocs/activity_bloc.dart
+++ b/lib/features/activity/presentation/blocs/activity_bloc.dart
@@ -85,7 +85,6 @@ class ActivityBloc extends BaseBloc<ActivityCommand, ActivityState, ActivityBloc
       _config = event.data;
       final next = _toOptions(
         _config,
-        debug: options?.debug ?? kDebugMode,
         defaultAccuracy: null,
       );
       final manual = await isManual;
@@ -173,7 +172,6 @@ class ActivityBloc extends BaseBloc<ActivityCommand, ActivityState, ActivityBloc
     final next = manual
         ? _toOptions(
             _config = config,
-            debug: (profile?.options ?? options)?.debug ?? kDebugMode,
             defaultAccuracy: profile?.options?.accuracy ?? options.accuracy,
           )
         // Override current if
@@ -257,11 +255,10 @@ class ActivityBloc extends BaseBloc<ActivityCommand, ActivityState, ActivityBloc
 
   LocationOptions _toOptions(
     AppConfig config, {
-    @required bool debug,
     @required LocationAccuracy defaultAccuracy,
   }) =>
       LocationOptions(
-        debug: debug,
+        locationDebug: config.locationDebug ?? Defaults.locationDebug,
         accuracy: _toAccuracy(config, defaultAccuracy),
         locationAlways: config.locationAlways ?? false,
         locationWhenInUse: config.locationWhenInUse ?? false,

--- a/lib/features/activity/presentation/blocs/activity_bloc.dart
+++ b/lib/features/activity/presentation/blocs/activity_bloc.dart
@@ -258,7 +258,7 @@ class ActivityBloc extends BaseBloc<ActivityCommand, ActivityState, ActivityBloc
     @required LocationAccuracy defaultAccuracy,
   }) =>
       LocationOptions(
-        locationDebug: config.locationDebug ?? Defaults.locationDebug,
+        debug: config.locationDebug ?? Defaults.locationDebug,
         accuracy: _toAccuracy(config, defaultAccuracy),
         locationAlways: config.locationAlways ?? false,
         locationWhenInUse: config.locationWhenInUse ?? false,

--- a/lib/features/mapping/data/services/background_geolocation_service.dart
+++ b/lib/features/mapping/data/services/background_geolocation_service.dart
@@ -172,7 +172,7 @@ class BackgroundGeolocationService implements LocationService {
           _isConfigChanged(
             duuid: duuid,
             token: token,
-            locationDebug: debug,
+            debug: debug,
             share: share,
             options: options ?? _options,
           );
@@ -184,7 +184,7 @@ class BackgroundGeolocationService implements LocationService {
 
         // Ensure debug flag is updated if given
         _options = (options ?? _options).copyWith(
-          locationDebug: debug ?? _options.debug,
+          debug: debug ?? _options.debug,
         );
         final config = _toConfig(
           duuid: duuid,
@@ -269,7 +269,7 @@ class BackgroundGeolocationService implements LocationService {
     );
     return bg.Config(
       reset: true,
-      debug: _locationDebug,
+      debug: _debug,
       url: _toUrl(),
       method: 'POST',
       batchSync: true,
@@ -305,7 +305,7 @@ class BackgroundGeolocationService implements LocationService {
     );
   }
 
-  bool get _locationDebug => (_options?.debug ?? kDebugMode);
+  bool get _debug => (_options?.debug ?? kDebugMode);
 
   String _toUrl({bool override = false}) =>
       override || isSharing ? '${Defaults.baseRestUrl}/devices/$_duuid/positions' : null;
@@ -431,12 +431,12 @@ class BackgroundGeolocationService implements LocationService {
 
   bool _isConfigChanged({
     bool share,
-    bool locationDebug,
+    bool debug,
     String duuid,
     AuthToken token,
     LocationOptions options,
   }) {
-    return _options?.debug != (locationDebug ?? options.debug ?? kDebugMode) ||
+    return _options?.debug != (debug ?? options.debug ?? kDebugMode) ||
         _options?.accuracy != options.accuracy ||
         _options?.locationAlways != (options.locationAlways ?? false) ||
         _options?.locationWhenInUse != (options.locationWhenInUse ?? false) ||

--- a/lib/features/mapping/data/services/background_geolocation_service.dart
+++ b/lib/features/mapping/data/services/background_geolocation_service.dart
@@ -153,7 +153,7 @@ class BackgroundGeolocationService implements LocationService {
   @override
   Future<LocationOptions> configure({
     bool share,
-    bool locationDebug,
+    bool debug,
     String duuid,
     AuthToken token,
     bool force = false,
@@ -172,7 +172,7 @@ class BackgroundGeolocationService implements LocationService {
           _isConfigChanged(
             duuid: duuid,
             token: token,
-            locationDebug: locationDebug,
+            locationDebug: debug,
             share: share,
             options: options ?? _options,
           );
@@ -184,7 +184,7 @@ class BackgroundGeolocationService implements LocationService {
 
         // Ensure debug flag is updated if given
         _options = (options ?? _options).copyWith(
-          locationDebug: locationDebug ?? _options.locationDebug,
+          locationDebug: debug ?? _options.debug,
         );
         final config = _toConfig(
           duuid: duuid,
@@ -305,7 +305,7 @@ class BackgroundGeolocationService implements LocationService {
     );
   }
 
-  bool get _locationDebug => (_options?.locationDebug ?? kDebugMode);
+  bool get _locationDebug => (_options?.debug ?? kDebugMode);
 
   String _toUrl({bool override = false}) =>
       override || isSharing ? '${Defaults.baseRestUrl}/devices/$_duuid/positions' : null;
@@ -326,7 +326,7 @@ class BackgroundGeolocationService implements LocationService {
 
   int get _persistMode => canStore ? bg.Config.PERSIST_MODE_LOCATION : bg.Config.PERSIST_MODE_NONE;
   int get _logLevel => Defaults.debugPrintLocation
-      ? ((_options?.locationDebug ?? kDebugMode) ? bg.Config.LOG_LEVEL_VERBOSE : bg.Config.LOG_LEVEL_INFO)
+      ? ((_options?.debug ?? kDebugMode) ? bg.Config.LOG_LEVEL_VERBOSE : bg.Config.LOG_LEVEL_INFO)
       : bg.Config.LOG_LEVEL_OFF;
 
   int _toAccuracy(LocationAccuracy accuracy) {
@@ -436,7 +436,7 @@ class BackgroundGeolocationService implements LocationService {
     AuthToken token,
     LocationOptions options,
   }) {
-    return _options?.locationDebug != (locationDebug ?? options.locationDebug ?? kDebugMode) ||
+    return _options?.debug != (locationDebug ?? options.debug ?? kDebugMode) ||
         _options?.accuracy != options.accuracy ||
         _options?.locationAlways != (options.locationAlways ?? false) ||
         _options?.locationWhenInUse != (options.locationWhenInUse ?? false) ||

--- a/lib/features/mapping/data/services/background_geolocation_service.dart
+++ b/lib/features/mapping/data/services/background_geolocation_service.dart
@@ -21,6 +21,7 @@ class BackgroundGeolocationService implements LocationService {
     String duuid,
     AuthToken token,
     bool share = false,
+    bool locationDebug = false,
     this.maxEvents = 100,
   }) {
     assert(options != null, "options are required");
@@ -152,7 +153,7 @@ class BackgroundGeolocationService implements LocationService {
   @override
   Future<LocationOptions> configure({
     bool share,
-    bool debug,
+    bool locationDebug,
     String duuid,
     AuthToken token,
     bool force = false,
@@ -171,7 +172,7 @@ class BackgroundGeolocationService implements LocationService {
           _isConfigChanged(
             duuid: duuid,
             token: token,
-            debug: debug,
+            locationDebug: locationDebug,
             share: share,
             options: options ?? _options,
           );
@@ -183,7 +184,7 @@ class BackgroundGeolocationService implements LocationService {
 
         // Ensure debug flag is updated if given
         _options = (options ?? _options).copyWith(
-          debug: debug ?? _options.debug,
+          locationDebug: locationDebug ?? _options.locationDebug,
         );
         final config = _toConfig(
           duuid: duuid,
@@ -268,7 +269,7 @@ class BackgroundGeolocationService implements LocationService {
     );
     return bg.Config(
       reset: true,
-      debug: _debug,
+      debug: _locationDebug,
       url: _toUrl(),
       method: 'POST',
       batchSync: true,
@@ -304,7 +305,7 @@ class BackgroundGeolocationService implements LocationService {
     );
   }
 
-  bool get _debug => _options.debug ?? kDebugMode;
+  bool get _locationDebug => (_options?.locationDebug ?? kDebugMode);
 
   String _toUrl({bool override = false}) =>
       override || isSharing ? '${Defaults.baseRestUrl}/devices/$_duuid/positions' : null;
@@ -325,7 +326,7 @@ class BackgroundGeolocationService implements LocationService {
 
   int get _persistMode => canStore ? bg.Config.PERSIST_MODE_LOCATION : bg.Config.PERSIST_MODE_NONE;
   int get _logLevel => Defaults.debugPrintLocation
-      ? ((_options?.debug ?? kDebugMode) ? bg.Config.LOG_LEVEL_VERBOSE : bg.Config.LOG_LEVEL_INFO)
+      ? ((_options?.locationDebug ?? kDebugMode) ? bg.Config.LOG_LEVEL_VERBOSE : bg.Config.LOG_LEVEL_INFO)
       : bg.Config.LOG_LEVEL_OFF;
 
   int _toAccuracy(LocationAccuracy accuracy) {
@@ -430,12 +431,12 @@ class BackgroundGeolocationService implements LocationService {
 
   bool _isConfigChanged({
     bool share,
-    bool debug,
+    bool locationDebug,
     String duuid,
     AuthToken token,
     LocationOptions options,
   }) {
-    return _options?.debug != (debug ?? options.debug ?? kDebugMode) ||
+    return _options?.locationDebug != (locationDebug ?? options.locationDebug ?? kDebugMode) ||
         _options?.accuracy != options.accuracy ||
         _options?.locationAlways != (options.locationAlways ?? false) ||
         _options?.locationWhenInUse != (options.locationWhenInUse ?? false) ||

--- a/lib/features/mapping/data/services/location_service.dart
+++ b/lib/features/mapping/data/services/location_service.dart
@@ -98,7 +98,7 @@ abstract class LocationService extends Service {
   /// Use [force] to force reconfiguration of service
   Future<LocationOptions> configure({
     bool share,
-    bool debug,
+    bool locationDebug,
     String duuid,
     AuthToken token,
     bool force = false,
@@ -197,7 +197,7 @@ class LocationOptions {
   /// - forceAndroidLocationManager: false
   /// - timeInterval: 0
   const LocationOptions({
-    this.debug = kDebugMode ?? false,
+    this.locationDebug = Defaults.locationDebug,
     this.locationAlways,
     this.locationWhenInUse,
     this.forceAndroidLocationManager,
@@ -211,7 +211,7 @@ class LocationOptions {
 
   /// Tells service to enter debug mode
   ///
-  final bool debug;
+  final bool locationDebug;
 
   /// Tells service to track location also when app is terminated by OS
   ///
@@ -256,7 +256,7 @@ class LocationOptions {
   final int timeInterval;
 
   LocationOptions copyWith({
-    bool debug,
+    bool locationDebug,
     int timeInterval,
     int distanceFilter,
     bool locationAlways,
@@ -268,7 +268,7 @@ class LocationOptions {
     LocationAccuracy accuracy = LocationAccuracy.best,
   }) =>
       LocationOptions(
-        debug: debug ?? this.debug,
+        locationDebug: locationDebug ?? this.locationDebug ?? Defaults.locationDebug,
         accuracy: accuracy ?? this.accuracy,
         locationAlways: locationAlways ?? this.locationAlways ?? false,
         locationWhenInUse: locationWhenInUse ?? this.locationWhenInUse ?? false,
@@ -281,6 +281,7 @@ class LocationOptions {
       );
 
   bool equals(AppConfig config) =>
+      locationDebug == config.locationDebug &&
       locationAlways == config.locationAlways &&
       locationWhenInUse == config.locationWhenInUse &&
       activityRecognition == config.activityRecognition &&
@@ -295,7 +296,7 @@ class LocationOptions {
       identical(this, other) ||
       other is LocationOptions &&
           runtimeType == other.runtimeType &&
-          debug == other.debug &&
+          locationDebug == other.locationDebug &&
           locationAlways == other.locationAlways &&
           locationWhenInUse == other.locationWhenInUse &&
           activityRecognition == other.activityRecognition &&
@@ -308,7 +309,7 @@ class LocationOptions {
 
   @override
   int get hashCode =>
-      debug.hashCode ^
+      locationDebug.hashCode ^
       locationAlways.hashCode ^
       locationWhenInUse.hashCode ^
       activityRecognition.hashCode ^
@@ -321,7 +322,7 @@ class LocationOptions {
 
   @override
   String toString() => 'Options: {\n'
-      '   debug: $debug\n'
+      '   locationDebug: $locationDebug\n'
       '   accuracy: $accuracy\n'
       '   timeInterval: $timeInterval\n'
       '   distanceFilter: $distanceFilter\n'

--- a/lib/features/mapping/data/services/location_service.dart
+++ b/lib/features/mapping/data/services/location_service.dart
@@ -256,7 +256,7 @@ class LocationOptions {
   final int timeInterval;
 
   LocationOptions copyWith({
-    bool locationDebug,
+    bool debug,
     int timeInterval,
     int distanceFilter,
     bool locationAlways,

--- a/lib/features/mapping/data/services/location_service.dart
+++ b/lib/features/mapping/data/services/location_service.dart
@@ -98,7 +98,7 @@ abstract class LocationService extends Service {
   /// Use [force] to force reconfiguration of service
   Future<LocationOptions> configure({
     bool share,
-    bool locationDebug,
+    bool debug,
     String duuid,
     AuthToken token,
     bool force = false,
@@ -197,7 +197,7 @@ class LocationOptions {
   /// - forceAndroidLocationManager: false
   /// - timeInterval: 0
   const LocationOptions({
-    this.locationDebug = Defaults.locationDebug,
+    this.debug = Defaults.locationDebug,
     this.locationAlways,
     this.locationWhenInUse,
     this.forceAndroidLocationManager,
@@ -211,7 +211,7 @@ class LocationOptions {
 
   /// Tells service to enter debug mode
   ///
-  final bool locationDebug;
+  final bool debug;
 
   /// Tells service to track location also when app is terminated by OS
   ///
@@ -268,7 +268,7 @@ class LocationOptions {
     LocationAccuracy accuracy = LocationAccuracy.best,
   }) =>
       LocationOptions(
-        locationDebug: locationDebug ?? this.locationDebug ?? Defaults.locationDebug,
+        debug: debug ?? this.debug ?? Defaults.locationDebug,
         accuracy: accuracy ?? this.accuracy,
         locationAlways: locationAlways ?? this.locationAlways ?? false,
         locationWhenInUse: locationWhenInUse ?? this.locationWhenInUse ?? false,
@@ -281,7 +281,7 @@ class LocationOptions {
       );
 
   bool equals(AppConfig config) =>
-      locationDebug == config.locationDebug &&
+      debug == config.locationDebug &&
       locationAlways == config.locationAlways &&
       locationWhenInUse == config.locationWhenInUse &&
       activityRecognition == config.activityRecognition &&
@@ -296,7 +296,7 @@ class LocationOptions {
       identical(this, other) ||
       other is LocationOptions &&
           runtimeType == other.runtimeType &&
-          locationDebug == other.locationDebug &&
+          debug == other.debug &&
           locationAlways == other.locationAlways &&
           locationWhenInUse == other.locationWhenInUse &&
           activityRecognition == other.activityRecognition &&
@@ -309,7 +309,7 @@ class LocationOptions {
 
   @override
   int get hashCode =>
-      locationDebug.hashCode ^
+      debug.hashCode ^
       locationAlways.hashCode ^
       locationWhenInUse.hashCode ^
       activityRecognition.hashCode ^
@@ -322,7 +322,7 @@ class LocationOptions {
 
   @override
   String toString() => 'Options: {\n'
-      '   locationDebug: $locationDebug\n'
+      '   locationDebug: $debug\n'
       '   accuracy: $accuracy\n'
       '   timeInterval: $timeInterval\n'
       '   distanceFilter: $distanceFilter\n'

--- a/lib/features/settings/data/models/app_config_model.dart
+++ b/lib/features/settings/data/models/app_config_model.dart
@@ -40,6 +40,7 @@ class AppConfigModel extends AppConfig implements JsonObject<Map<String, dynamic
     SecurityMode securityMode = Defaults.securityMode,
     List<String> trustedDomains = Defaults.trustedDomains,
     int securityLockAfter = Defaults.securityLockAfter,
+    bool locationDebug = Defaults.locationDebug,
   }) : super(
           uuid: uuid,
           udid: udid,
@@ -52,6 +53,7 @@ class AppConfigModel extends AppConfig implements JsonObject<Map<String, dynamic
           onboarded: onboarded ?? false,
           firstSetup: firstSetup ?? false,
           talkGroups: talkGroups ?? <String>[],
+          locationDebug: locationDebug ?? Defaults.locationDebug,
           locationAlways: locationAlways ?? false,
           idpHints: idpHints ?? Defaults.idpHints,
           locationWhenInUse: locationWhenInUse ?? false,
@@ -108,6 +110,7 @@ class AppConfigModel extends AppConfig implements JsonObject<Map<String, dynamic
     SecurityMode securityMode,
     List<String> trustedDomains,
     int securityLockAfter,
+    bool locationDebug,
   }) {
     return AppConfigModel(
       uuid: uuid ?? this.uuid,
@@ -140,6 +143,7 @@ class AppConfigModel extends AppConfig implements JsonObject<Map<String, dynamic
       securityMode: securityMode ?? this.securityMode,
       trustedDomains: trustedDomains ?? this.trustedDomains,
       securityLockAfter: securityLockAfter ?? this.securityLockAfter,
+      locationDebug: locationDebug ?? this.locationDebug,
     );
   }
 

--- a/lib/features/settings/data/models/app_config_model.g.dart
+++ b/lib/features/settings/data/models/app_config_model.g.dart
@@ -41,6 +41,7 @@ AppConfigModel _$AppConfigModelFromJson(Map json) {
     trustedDomains:
         (json['trustedDomains'] as List)?.map((e) => e as String)?.toList(),
     securityLockAfter: json['securityLockAfter'] as int,
+    locationDebug: json['locationDebug'] as bool,
   );
 }
 
@@ -84,6 +85,7 @@ Map<String, dynamic> _$AppConfigModelToJson(AppConfigModel instance) {
   writeNotNull('securityMode', _$SecurityModeEnumMap[instance.securityMode]);
   writeNotNull('trustedDomains', instance.trustedDomains);
   writeNotNull('securityLockAfter', instance.securityLockAfter);
+  writeNotNull('locationDebug', instance.locationDebug);
   return val;
 }
 

--- a/lib/features/settings/data/services/app_config_service.dart
+++ b/lib/features/settings/data/services/app_config_service.dart
@@ -25,7 +25,9 @@ abstract class AppConfigServiceImpl extends StatefulService<AppConfig, AppConfig
   AppConfigServiceImpl()
       : super(
           decoder: (json) => AppConfigModel.fromJson(json),
-          reducer: (value) => JsonUtils.toJson<AppConfigModel>(value),
+          reducer: (value) => JsonUtils.toJson<AppConfigModel>(value, remove: const [
+            'locationDebug',
+          ]),
         );
   static AppConfigServiceImpl newInstance([ChopperClient client]) => _$AppConfigServiceImpl(client);
 

--- a/lib/features/settings/domain/entities/AppConfig.dart
+++ b/lib/features/settings/domain/entities/AppConfig.dart
@@ -39,6 +39,7 @@ abstract class AppConfig extends Aggregate<Map<String, dynamic>> {
     this.securityMode = Defaults.securityMode,
     this.trustedDomains = Defaults.trustedDomains,
     this.securityLockAfter = Defaults.securityLockAfter,
+    this.locationDebug = Defaults.locationDebug,
   })  : this.talkGroups = talkGroups ?? const <String>[],
         this.units = units ?? const <String>[],
         super(uuid, fields: [
@@ -71,6 +72,7 @@ abstract class AppConfig extends Aggregate<Map<String, dynamic>> {
           securityMode,
           trustedDomains,
           securityLockAfter,
+          locationDebug,
         ]);
   final String udid;
   final int version;
@@ -101,6 +103,7 @@ abstract class AppConfig extends Aggregate<Map<String, dynamic>> {
   final SecurityMode securityMode;
   final List<String> trustedDomains;
   final int securityLockAfter;
+  final bool locationDebug;
 
   AppConfig copyWith({
     String uuid,
@@ -136,6 +139,7 @@ abstract class AppConfig extends Aggregate<Map<String, dynamic>> {
     SecurityMode securityMode,
     List<String> trustedDomains,
     int securityLockAfter,
+    bool locationDebug,
   });
 
   DemoParams toDemoParams() => DemoParams(demo, role: toRole());

--- a/lib/features/settings/presentation/blocs/app_config_bloc.dart
+++ b/lib/features/settings/presentation/blocs/app_config_bloc.dart
@@ -89,6 +89,7 @@ class AppConfigBloc
     SecurityMode securityMode,
     List<String> trustedDomains,
     int securityLockAfter,
+    bool locationDebug,
   }) async {
     if (!isReady) return Future.error("AppConfig not ready");
     final config = this.config.copyWith(
@@ -118,8 +119,9 @@ class AppConfigBloc
           units: units,
           securityType: securityType,
           securityMode: securityMode,
-          securityLockAfter: securityLockAfter,
           trustedDomains: trustedDomains,
+          securityLockAfter: securityLockAfter,
+          locationDebug: locationDebug,
         );
     return update(config);
   }

--- a/lib/features/settings/presentation/screens/location_config_screen.dart
+++ b/lib/features/settings/presentation/screens/location_config_screen.dart
@@ -43,7 +43,7 @@ class _LocationConfigScreenState extends State<LocationConfigScreen> {
   bool get locationAllowSharing =>
       _manual ? context.bloc<AppConfigBloc>().config.locationAllowSharing : options.locationAllowSharing;
 
-  bool get _locationDebug => _manual ? context.bloc<AppConfigBloc>().config.locationDebug : options.locationDebug;
+  bool get _locationDebug => _manual ? context.bloc<AppConfigBloc>().config.locationDebug : options.debug;
 
   @override
   void dispose() {
@@ -321,7 +321,7 @@ class _LocationConfigScreenState extends State<LocationConfigScreen> {
                 locationDebug: value,
               );
           await LocationService().configure(
-            locationDebug: value,
+            debug: value,
           );
           setState(() {});
         });


### PR DESCRIPTION
Rename debug to locationDebug
Move the setting to AppConfig
Make the app_controller read the the locationDebug setting from AppConfig when configuring the location service on startup.