### PR TITLE
Only show number keyboard when entering PIN codes, closes #135

### DIFF
--- a/lib/features/user/presentation/screens/change_pin_screen.dart
+++ b/lib/features/user/presentation/screens/change_pin_screen.dart
@@ -323,6 +323,7 @@ class ChangePinScreenState extends State<ChangePinScreen> with TickerProviderSta
             FilteringTextInputFormatter.allow(RegExp('[0-9]')),
           ],
           textInputAction: TextInputAction.send,
+          keyboardType: TextInputType.number,
           animationType: AnimationType.fade,
           autoDismissKeyboard: false,
           animationDuration: Duration(milliseconds: 300),

--- a/lib/features/user/presentation/screens/unlock_screen.dart
+++ b/lib/features/user/presentation/screens/unlock_screen.dart
@@ -381,6 +381,7 @@ class UnlockScreenState extends State<UnlockScreen> with TickerProviderStateMixi
             FilteringTextInputFormatter.allow(RegExp('[0-9]')),
           ],
           textInputAction: TextInputAction.send,
+          keyboardType: TextInputType.number,
           animationType: AnimationType.fade,
           autoDismissKeyboard: false,
           autoDisposeControllers: false,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ version: 0.1.1+86
 
 environment:
   sdk: ">=2.11.0 <3.0.0"
-  flutter: ">=2.0.4"
+  flutter: ">=2.0.5"
 
 dependencies:
   flutter:
@@ -68,7 +68,7 @@ dependencies:
   connectivity: ^3.0.3
   data_connection_checker: ^0.3.4
   xml: ^4.5.1
-  pin_code_fields: ^6.1.0
+  pin_code_fields: ^7.0.0
   local_auth: ^1.1.4
   hive: ^1.4.4+1
   hive_flutter: ^0.3.0+2


### PR DESCRIPTION
- Change to pin_code_fields 7.0.0
- add "keyboardType: TextInputType.number" to Widgets

+ Change from flutter 2.0.4 to 2.0.5